### PR TITLE
feat: show success toast on quote submit and mount global Toaster\n\n…

### DIFF
--- a/app/components/BookingForm.tsx
+++ b/app/components/BookingForm.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { useQuote } from "../context/QuoteContext";
+import { toast } from "@/hooks/use-toast";
 import { useRouter } from "next/navigation";
 
 export default function BookingForm({ open, setOpen }: { open: boolean; setOpen: (open: boolean) => void }) {
@@ -78,7 +79,11 @@ export default function BookingForm({ open, setOpen }: { open: boolean; setOpen:
       if (res.ok) {
         clearQuote();
         setOpen(false);
-        router.push("/?quote=success");
+        toast({
+          title: "Request submitted",
+          description: "Thank you! We\'ll contact you shortly.",
+        });
+        router.push("/");
         // If a new quote was created, update currentQuoteRequestId
         if (apiMethod === "POST") {
           const newQuoteRequest = await res.json();

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import './globals.css'
+import { Toaster } from '@/components/ui/toaster'
 
 export const metadata: Metadata = {
   title: 'Smart Agri Solutions',
@@ -17,7 +18,10 @@ export default function RootLayout({
       <head>
         <link rel="icon" href="/Logo2.png" type="image/png" />
       </head>
-      <body>{children}</body>
+      <body>
+        {children}
+        <Toaster />
+      </body>
     </html>
   )
 }


### PR DESCRIPTION
…- Mount <Toaster /> in app/layout.tsx for global toast support\n- Trigger toast on successful BookingForm submission and navigate cleanly to /\n- Remove reliance on query param (?quote=success) for confirmation UX